### PR TITLE
"Required value 'date' missing at $.main  - Fatal Exception "

### DIFF
--- a/app/src/main/java/com/example/weatherapp2/ui/ForecastScreen.kt
+++ b/app/src/main/java/com/example/weatherapp2/ui/ForecastScreen.kt
@@ -110,6 +110,7 @@ private fun DayForecastContent(
                 style = textStyle,
             )
         }
+        //Figure out crash at this portion
     }
 }
 


### PR DESCRIPTION
Implemented everything required for the Forecast View Model but the app crashes upon pressing the forecast button. Logcat gives: FATAL EXCEPTION: main
    Process: com.example.weatherapp2, PID: 13393
    com.squareup.moshi.JsonDataException: Required value 'date' missing at $.main

Not sure how to diagnose